### PR TITLE
Cast addresses to `long`

### DIFF
--- a/gdb-ghcrts.py
+++ b/gdb-ghcrts.py
@@ -153,7 +153,7 @@ class TSO:
         base = stack['stack'].cast(StgWord_p)
         top = base + int(stack['stack_size'])
         #print("    stack", sp, "->", top)
-        while int(sp) < int(top):
+        while long(sp) < long(top):
             obj = Closure(sp)
             yield obj
             sp += obj.frame_size()


### PR DESCRIPTION
My gdb (7.12.0) was erroring with `error: value cannot be converted to int`.

Converting the values (addresses) to a `long` solves the issue.